### PR TITLE
Update Proton Mail URL

### DIFF
--- a/APPS.md
+++ b/APPS.md
@@ -702,7 +702,7 @@
 - [K-9 Mail/Thunderbird Android](https://github.com/thunderbird/thunderbird-android)
   - [monocles mail](https://codeberg.org/Arne/monocles_mail) **`FORK`**
 - [Ltt.rs](https://codeberg.org/iNPUTmice/lttrs-android)
-- [Proton Mail](https://github.com/ProtonMail/proton-mail-android) **`DEAD`**
+- [Proton Mail](https://github.com/ProtonMail/android-mail)
 - [SimpleLogin](https://github.com/simple-login/Simple-Login-Android)
 - [Tutanota](https://github.com/tutao/tutanota)
 

--- a/apps.json
+++ b/apps.json
@@ -8318,9 +8318,9 @@
   },
   {
     "applicationName": "Proton Mail",
-    "url": "https://github.com/ProtonMail/proton-mail-android",
+    "url": "https://github.com/ProtonMail/android-mail",
     "downloadUrl": [],
-    "isDead": true,
+    "isDead": false,
     "isFork": false,
     "tags": [
       "Email",


### PR DESCRIPTION
Proton mail was marked as dead, the URL simply changed to https://github.com/ProtonMail/android-mail, so I removed the "DEAD" mention and updated the URL